### PR TITLE
Added erratum for 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | ----- |-------------|------------|
 | 115 | scoreというパラメーターが渡って来ます。| human, computer, judgmentというパラメーターが渡って来ます。 |
 | 103 | `<img src=""logo.png"" ... />` | `<img src="logo.png" ... />`   (3か所あります) |
+| 200 | `import from './helper'` | `import { touchTap } from './helper'` |
 
 
 ## リンク


### PR DESCRIPTION
書籍の200ページ  `test/index.js` の3行目

```
import from './helper'
```

の部分は、Syntax Errorになります。

[GitHub上のサンプルコード](https://github.com/yuumi3/react_book/blob/master/sources/test.md#8-3-3-%E3%83%86%E3%82%B9%E3%83%88%E3%82%B3%E3%83%BC%E3%83%89)では

```
import from './helper'
```

とあったので、正誤表に追加しておきました。

